### PR TITLE
xplanet: Version bump to 1.3.1

### DIFF
--- a/packages/x11-apps/xplanet/files/xplanet-1.3.1-remove-NULL-comparison-for-getline-calls.patch
+++ b/packages/x11-apps/xplanet/files/xplanet-1.3.1-remove-NULL-comparison-for-getline-calls.patch
@@ -1,0 +1,172 @@
+Upstream: yes
+Reason: Fix build with gcc 6
+
+From d0b4cd857002e2430c0c606dbb911539613c425d Mon Sep 17 00:00:00 2001
+From: hari <hari@63acc863-b1ee-4aef-a14a-77ae96d11755>
+Date: Thu, 24 Mar 2016 11:36:25 +0000
+Subject: [PATCH] remove NULL comparison for getline() calls
+
+git-svn-id: svn://svn.code.sf.net/p/xplanet/code/trunk@207 63acc863-b1ee-4aef-a14a-77ae96d11755
+---
+ src/libannotate/addArcs.cpp            | 4 ++--
+ src/libannotate/addMarkers.cpp         | 4 ++--
+ src/libannotate/addSatellites.cpp      | 8 ++++----
+ src/libannotate/addSpiceObjects.cpp    | 4 ++--
+ src/libmultiple/RayleighScattering.cpp | 6 +++---
+ src/libmultiple/drawStars.cpp          | 2 +-
+ src/readConfig.cpp                     | 2 +-
+ 7 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/libannotate/addArcs.cpp b/src/libannotate/addArcs.cpp
+index 2ee06c0..0ff5478 100644
+--- a/src/libannotate/addArcs.cpp
++++ b/src/libannotate/addArcs.cpp
+@@ -258,7 +258,7 @@ addArcs(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(arcFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+                 readArcFile(line, planet, view, projection,
+                             planetProperties, annotationMap);
+             
+@@ -292,7 +292,7 @@ addArcs(View *view, multimap<double, Annotation *> &annotationMap)
+         {
+             ifstream inFile(arcFile.c_str());
+             char *line = new char[256];
+-            while (inFile.getline (line, 256, '\n') != NULL)
++            while (inFile.getline (line, 256, '\n'))
+                 readArcFile(line, NULL, view, NULL, NULL, annotationMap);
+ 
+             inFile.close();
+diff --git a/src/libannotate/addMarkers.cpp b/src/libannotate/addMarkers.cpp
+index dde51c1..d0b5e41 100644
+--- a/src/libannotate/addMarkers.cpp
++++ b/src/libannotate/addMarkers.cpp
+@@ -429,7 +429,7 @@ addMarkers(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(markerFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+             {
+                 unsigned char color[3];
+                 memcpy(color, planetProperties->MarkerColor(), 3);
+@@ -475,7 +475,7 @@ addMarkers(View *view, const int width, const int height,
+         {
+             ifstream inFile(markerFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+             {
+                 unsigned char color[3];
+                 memcpy(color, options->Color(), 3);
+diff --git a/src/libannotate/addSatellites.cpp b/src/libannotate/addSatellites.cpp
+index 2634339..920d2cb 100644
+--- a/src/libannotate/addSatellites.cpp
++++ b/src/libannotate/addSatellites.cpp
+@@ -488,10 +488,10 @@ loadSatelliteVector(PlanetProperties *planetProperties)
+         {
+             ifstream inFile(tleFile.c_str());
+             char lines[3][80];
+-            while (inFile.getline(lines[0], 80) != NULL)
++            while (inFile.getline(lines[0], 80))
+             {
+-                if ((inFile.getline(lines[1], 80) == NULL) 
+-                    || (inFile.getline(lines[2], 80) == NULL))
++                if ((!inFile.getline(lines[1], 80)) 
++                    || (!inFile.getline(lines[2], 80)))
+                 {
+                     ostringstream errStr;
+                     errStr << "Malformed TLE file (" << tleFile << ")?\n";
+@@ -542,7 +542,7 @@ addSatellites(PlanetProperties *planetProperties, Planet *planet,
+         {
+             ifstream inFile(satFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline (line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline (line, MAX_LINE_LENGTH, '\n'))
+                 readSatelliteFile(line, planet, view, projection,
+                                   planetProperties, annotationMap);
+             
+diff --git a/src/libannotate/addSpiceObjects.cpp b/src/libannotate/addSpiceObjects.cpp
+index 67b752c..feb3e63 100644
+--- a/src/libannotate/addSpiceObjects.cpp
++++ b/src/libannotate/addSpiceObjects.cpp
+@@ -524,7 +524,7 @@ processSpiceKernels(const bool load)
+         {
+             ifstream inFile(kernelFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+             {
+                 int ii = 0;
+                 while (isDelimiter(line[ii]))
+@@ -576,7 +576,7 @@ addSpiceObjects(map<double, Planet *> &planetsFromSunMap,
+         {
+             ifstream inFile(spiceFile.c_str());
+             char *line = new char[MAX_LINE_LENGTH];
+-            while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++            while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+                 readSpiceFile(line, planetsFromSunMap, view, projection,
+                               annotationMap);
+             inFile.close();
+diff --git a/src/libmultiple/RayleighScattering.cpp b/src/libmultiple/RayleighScattering.cpp
+index d885173..7c25c1c 100644
+--- a/src/libmultiple/RayleighScattering.cpp
++++ b/src/libmultiple/RayleighScattering.cpp
+@@ -369,7 +369,7 @@ RayleighScattering::readConfigFile(string configFile)
+ 
+     diskTemplate_.clear();
+     limbTemplate_.clear();
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+@@ -439,7 +439,7 @@ RayleighScattering::readBlock(ifstream &inFile,
+     values.clear();
+ 
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+@@ -470,7 +470,7 @@ RayleighScattering::readValue(ifstream &inFile,
+                               double &value)
+ {
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         int i = 0;
+         while (isDelimiter(line[i]))
+diff --git a/src/libmultiple/drawStars.cpp b/src/libmultiple/drawStars.cpp
+index ff07c49..22e41a0 100644
+--- a/src/libmultiple/drawStars.cpp
++++ b/src/libmultiple/drawStars.cpp
+@@ -41,7 +41,7 @@ drawStars(DisplayBase *display, View *view)
+     ifstream inFile(starMap.c_str());
+ 
+     char line[MAX_LINE_LENGTH];
+-    while (inFile.getline(line, MAX_LINE_LENGTH, '\n') != NULL)
++    while (inFile.getline(line, MAX_LINE_LENGTH, '\n'))
+     {
+         if (line[0] == '#') continue;
+ 
+diff --git a/src/readConfig.cpp b/src/readConfig.cpp
+index cc1964f..2946690 100644
+--- a/src/readConfig.cpp
++++ b/src/readConfig.cpp
+@@ -550,7 +550,7 @@ readConfigFile(string configFile, PlanetProperties *planetProperties[])
+ 
+         ifstream inFile(configFile.c_str());
+         char *line = new char[256];
+-        while (inFile.getline(line, 256, '\n') != NULL)
++        while (inFile.getline(line, 256, '\n'))
+             readConfig(line, planetProperties);
+         
+         // This condition will only be true if [default] is the only
+-- 
+2.8.2
+

--- a/packages/x11-apps/xplanet/xplanet-1.3.1.exheres-0
+++ b/packages/x11-apps/xplanet/xplanet-1.3.1.exheres-0
@@ -32,6 +32,10 @@ DEPENDENCIES="
         x11-libs/libXext
 "
 
+DEFAULT_SRC_PREPARE_PATCHES=(
+    "${FILES}"/${PNV}-remove-NULL-comparison-for-getline-calls.patch
+)
+
 DEFAULT_SRC_CONFIGURE_PARAMS=(
     --without-aqua
     --without-cspice


### PR DESCRIPTION
The release isn't properly linked yet, but the tarball is there and
according to [1] it's an official release.

This also fixes building with gcc 6.

[1] http://xplanet.sourceforge.net/FUDforum2/index.php?t=msg
 &goto=2533&S=4f3b66056b22bd35ed2768fe4b3ba010#msg_2533

Change-Id: I223c26f2a5bad9aefc38884f8613887e3f1d9f41
