### PR TITLE
dstat: backport patches from "dool" fork

### DIFF
--- a/packages/sys-apps/dstat/dstat-0.7.4-r1.exheres-0
+++ b/packages/sys-apps/dstat/dstat-0.7.4-r1.exheres-0
@@ -25,8 +25,20 @@ DEPENDENCIES="
 
 RESTRICT="test"
 
+DEFAULT_SRC_PREPARE_PATCHES=(
+    "${FILES}"/Dool-fix-for-some-Python-deprecations.patch
+    "${FILES}"/Make-CSV-output-work-again.patch
+)
+
 DEFAULT_SRC_INSTALL_PARAMS=(
     DESTDIR="${IMAGE}"
     bindir="/usr/$(exhost --target)/bin"
 )
+
+src_prepare() {
+    default
+    edo sed \
+        -e "1 s|bin.\+$|$(exhost --target)/bin/python$(python_get_abi)|" \
+        -i "${PN}"
+}
 

--- a/packages/sys-apps/dstat/files/Dool-fix-for-some-Python-deprecations.patch
+++ b/packages/sys-apps/dstat/files/Dool-fix-for-some-Python-deprecations.patch
@@ -1,0 +1,48 @@
+Source: https://github.com/scottchiefbaker/dool/ (dstat fork)
+
+From 0caaccc1b2faf70e23bee937b528eab14880dd14 Mon Sep 17 00:00:00 2001
+From: Scott Baker <scott@perturb.org>
+Date: Sun, 14 Jul 2019 18:30:10 -0700
+Subject: [PATCH] Dool fix for some Python deprecations
+
+---
+ dstat | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/dstat b/dstat
+index 9ad7db6..bad8c1b 100755
+--- a/dstat
++++ b/dstat
+@@ -19,7 +19,6 @@
+ from __future__ import absolute_import, division, generators, print_function
+ __metaclass__ = type
+
+-import collections
+ import fnmatch
+ import getopt
+ import getpass
+@@ -33,6 +32,12 @@ import six
+ import sys
+ import time
+
++# https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7
++try:
++    from collections.abc import Sequence # Python 3.8+
++except ImportError:
++    from collections import Sequence # Python 2.x
++
+ VERSION = '0.8.0'
+
+ theme = { 'default': '' }
+@@ -531,7 +536,7 @@ class dstat:
+                 scale = self.scales[i]
+             else:
+                 scale = self.scale
+-            if isinstance(self.val[name], collections.Sequence) and not isinstance(self.val[name], six.string_types):
++            if isinstance(self.val[name], Sequence) and not isinstance(self.val[name], six.string_types):
+                 line = line + cprintlist(self.val[name], ctype, self.width, scale)
+                 sep = theme['frame'] + char['colon']
+                 if i + 1 != len(self.vars):
+--
+2.28.0
+

--- a/packages/sys-apps/dstat/files/Make-CSV-output-work-again.patch
+++ b/packages/sys-apps/dstat/files/Make-CSV-output-work-again.patch
@@ -1,0 +1,33 @@
+Source: https://github.com/scottchiefbaker/dool/ (dstat fork)
+
+From b168d380e7b8fc089eba3536290c6e0fc70666e6 Mon Sep 17 00:00:00 2001
+From: Scott Baker <scott.baker@directlink.coop>
+Date: Thu, 22 Aug 2019 16:52:01 -0700
+Subject: [PATCH] Make CSV output work again
+
+---
+ dstat | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dstat b/dstat
+index 7cf46e0..1df6f68 100755
+--- a/dstat
++++ b/dstat
+@@ -572,12 +572,12 @@ class dstat:
+
+         line = ''
+         for i, name in enumerate(self.vars):
+-            if isinstance(self.val[name], types.ListType) or isinstance(self.val[name], types.TupleType):
++            if isinstance(self.val[name], list) or isinstance(self.val[name], tuple):
+                 for j, val in enumerate(self.val[name]):
+                     line = line + printcsv(val)
+                     if j + 1 != len(self.val[name]):
+                         line = line + char['sep']
+-            elif isinstance(self.val[name], types.StringType):
++            elif isinstance(self.val[name], str):
+                 line = line + self.val[name]
+             else:
+                 line = line + printcsv(self.val[name])
+--
+2.28.0
+


### PR DESCRIPTION
Fix incompatibilities with future Python versions.
Fix broken CSV output.
Force using python binary specified in python_abis.