### PR TITLE
iptraf-ng: install man to /usr/share

### DIFF
--- a/packages/net-analyzer/iptraf-ng/iptraf-ng-1.2.0-r1.exheres-0
+++ b/packages/net-analyzer/iptraf-ng/iptraf-ng-1.2.0-r1.exheres-0
@@ -27,10 +27,10 @@ DEPENDENCIES="
         sys-libs/ncurses[>=5.7]
 "
 
-src_configure() {
-    edo sed -ie "s|^prefix = .*|prefix = /usr/$(exhost --target)/|" Makefile
-    edo sed -ie "s|^sbindir_relative =.*|sbindir_relative = bin|" Makefile
-}
-
 DEFAULT_SRC_COMPILE_PARAMS=( CC=$(exhost --tool-prefix)cc )
+DEFAULT_SRC_INSTALL_PARAMS=(
+    prefix="/usr/$(exhost --target)"
+    sbindir_relative=bin
+    mandir=/usr/share/man
+)
 


### PR DESCRIPTION
and use install params since the makefile can handle install without sed