### PR TITLE
hyprland-qtutils: CMake configuration failure, missing Qt Wayland private module

### DIFF
--- a/packages/dev-libs/hyprland-qtutils/hyprland-qtutils-0.1.3.exheres-0
+++ b/packages/dev-libs/hyprland-qtutils/hyprland-qtutils-0.1.3.exheres-0
@@ -15,5 +15,11 @@ DEPENDENCIES="
     build+run:
         dev-libs/hyprutils
         x11-libs/qtbase:6[gui][>=6.5]
+        x11-libs/qtdeclarative:6
+        x11-libs/qtwayland:6
 "
+
+CMAKE_SRC_CONFIGURE_PARAMS=(
+    -DQT_FIND_PRIVATE_MODULES:BOOL=ON
+)
 


### PR DESCRIPTION
# Problem

 Configuring hyprland-qtutils-0.1.3 failed. Upstream's CMakeLists.txt links against the `Qt6::WaylandClientPrivate` target, but only requests the public `WaylandClient` component via `find_package`. As a result, the private target is never created by Qt, and CMake aborts on a missing target.

On top of that, the package didn't declare some Qt dependencies that are actually required for the build (qtdeclarative and qtwayland).

 # Fix

- Enable Qt's private modules via `-DQT_FIND_PRIVATE_MODULES:BOOL=ON` in `CMAKE_SRC_CONFIGURE_PARAMS`, so the `Qt6::WaylandClientPrivate` target is properly generated.
- Add the missing build+run dependencies:
    - x11-libs/qtdeclarative:6
    - x11-libs/qtwayland:6