### PR TITLE
Hyprland: version bump to 0.55.4

### DIFF
--- a/packages/compositor/Hyprland/Hyprland-0.55.4.exheres-0
+++ b/packages/compositor/Hyprland/Hyprland-0.55.4.exheres-0
@@ -11,30 +11,39 @@ CMAKE_SOURCE="${WORKBASE}/hyprland-source"
 LICENCES="BSD-3"
 SLOT="0"
 PLATFORMS="~amd64"
-MYOPTIONS=""
+MYOPTIONS="
+    hyprland-protocols [[ description = [ Use the system hyprland-protocols instead of the bundled copy ] ]]
+"
 
 DEPENDENCIES="
+    build:
+        hyprland-protocols? ( dev-libs/hyprland-protocols[>=0.6.4] )
     build+run:
-        dev-libs/aquamarine[>=0.8.0]
+        dev-lang/glslang
+        dev-lang/lua:5.5
+        dev-libs/aquamarine[>=0.9.3]
+        dev-libs/glaze[>=7.0.0&<8.0.0]
         dev-libs/glib:2
-        dev-libs/glaze[>=4.2.3]
         dev-libs/hyprcursor[>=0.1.7]
-        dev-libs/hyprgraphics[>=0.1.1]
-        dev-libs/hyprlang[>=0.3.2]
-        dev-libs/hyprutils[>=0.5.1]
+        dev-libs/hyprgraphics[>=0.5.1]
+        dev-libs/hyprlang[>=0.6.7]
+        dev-libs/hyprutils[>=0.13.1]
+        dev-libs/hyprwire
+        dev-libs/muparser
         dev-libs/re2
         dev-libs/udis86[>=1.7.2]
-        dev-util/hyprwayland-scanner[>=0.3.10]
+        dev-util/hyprwayland-scanner[>=0.4.5]
+        media-libs/lcms2
         sys-apps/util-linux
-        sys-libs/libinput
-        sys-libs/wayland-protocols[>=1.41]
-        sys-libs/wayland[>=1.22.90]
+        sys-libs/libinput[>=1.28]
+        sys-libs/wayland-protocols[>=1.47]
+        sys-libs/wayland[>=1.22.91]
         x11-dri/libdrm
         x11-dri/mesa
         x11-libs/cairo
         x11-libs/libxcb
         x11-libs/libXcursor
-        x11-libs/libxkbcommon
+        x11-libs/libxkbcommon[>=1.11.0]
         x11-libs/pango
         x11-libs/pixman:1
         x11-utils/xcb-util-errors
@@ -43,13 +52,4 @@ DEPENDENCIES="
         dev-libs/hyprland-qtutils
         sys-apps/xdg-desktop-portal-wlr
 "
-
-DEFAULT_SRC_PREPARE_PATCHES=("${FILES}/0001-remove-udis86-check-it-doesn-t-provide-.pc-file.patch")
-
-src_prepare() {
-    cmake_src_prepare
-
-    # avoid voiding version.h when building from tarball, which breaks hyprpm
-    edo rm "${CMAKE_SOURCE}"/scripts/generateVersion.sh
-}
 


### PR DESCRIPTION
Hi! For context: I'm working through bumping the Hyprland ecosystem so I can run the latest release on my own system. 
  
Hyprland 0.55 pulls in a couple of new dependencies that weren't packaged anywhere yet : `dev-libs/muparser` (config math expressions) and `dev-libs/hyprwire` (the new IPC wire protocol used by hyprctl). I've packaged both in my personal overlay for now, but that repo is very young and isn't really used or considered trustworthy by anyone yet.

Would you rather I create these packages directly in this repo instead, so they live alongside Hyprland and its other deps? Happy to open PRs for them here if you prefer, just let me know which way you'd like to go.